### PR TITLE
[fix] namespace now matches project structure

### DIFF
--- a/src/org/clojars/smee/binary/demo/mp3.clj
+++ b/src/org/clojars/smee/binary/demo/mp3.clj
@@ -1,6 +1,6 @@
 (ns ^{:doc "MP3 IDv2 tags, according to the current specification at http://www.id3.org/id3v2.4.0-structure"
       :author "Steffen Dienst"} 
-  siemens-pv-data.mp3
+  org.clojars.smee.binary.demo.mp3
   (:use clojure.test
         org.clojars.smee.binary.core))
 


### PR DESCRIPTION
Only a minor fix, though in my app it causes a compiler error. Maybe you should also consider moving the demos out of the clojar?

Great library BTW!